### PR TITLE
Adjust template handling, add hook to alter promotion display

### DIFF
--- a/iq_commerce.module
+++ b/iq_commerce.module
@@ -236,3 +236,15 @@ function iq_commerce_page_attachments(array &$attachments) {
   $attachments['#attached']['library'][] = 'iq_commerce/checkout';
   $attachments['#attached']['library'][] = 'iq_commerce/customer';
 }
+
+/**
+ * Implements hook_commerce_inline_form_PLUGIN_ID_alter().
+ *
+ * Adjust style of buttons in coupon inline form to btn-secondary.
+ */
+function iq_commerce_promotion_commerce_inline_form_coupon_redemption_alter(array &$inline_form, FormStateInterface $form_state, array &$complete_form) {
+  $inline_form['apply']['#attributes']['class'][] = 'btn-secondary';
+  foreach ($inline_form['coupons'] as &$line) {
+    $line['remove_button']['#attributes']['class'][] = 'btn-secondary';
+  }
+}

--- a/iq_commerce.module
+++ b/iq_commerce.module
@@ -25,7 +25,20 @@ function iq_commerce_mail($key, &$message, $params) {
 }
 
 /**
+ * Implements hook_theme_registry_alter().
+ *
+ * Override paths if bootstrap_barrio is used.
+ */
+function iq_commerce_theme_registry_alter(&$theme_registry) {
+  if (str_contains($theme_registry['commerce_checkout_form__with_sidebar']['path'], 'bootstrap_barrio')) {
+    $theme_registry['commerce_checkout_form__with_sidebar']['path'] = \Drupal::service('extension.list.module')->getPath('iq_commerce') . '/templates/commerce/';
+  }
+}
+
+/**
  * Implements hook_theme().
+ *
+ * Add additional templates.
  */
 function iq_commerce_theme($existing, $type, $theme, $path) {
   return [

--- a/iq_commerce.module
+++ b/iq_commerce.module
@@ -255,9 +255,11 @@ function iq_commerce_page_attachments(array &$attachments) {
  *
  * Adjust style of buttons in coupon inline form to btn-secondary.
  */
-function iq_commerce_promotion_commerce_inline_form_coupon_redemption_alter(array &$inline_form, FormStateInterface $form_state, array &$complete_form) {
+function iq_commerce_commerce_inline_form_coupon_redemption_alter(array &$inline_form, FormStateInterface $form_state, array &$complete_form) {
   $inline_form['apply']['#attributes']['class'][] = 'btn-secondary';
-  foreach ($inline_form['coupons'] as &$line) {
-    $line['remove_button']['#attributes']['class'][] = 'btn-secondary';
+  if (!empty($inline_form['coupons'])) {
+    foreach ($inline_form['coupons'] as &$line) {
+      $line['remove_button']['#attributes']['class'][] = 'btn-secondary';
+    }
   }
 }

--- a/resources/sass/checkout.scss
+++ b/resources/sass/checkout.scss
@@ -522,7 +522,7 @@
       margin: 15px 0;
     }
 
-    .table {
+    table, .table {
       font-size: $font-size-standard;
 
       tr {

--- a/resources/sass/checkout.scss
+++ b/resources/sass/checkout.scss
@@ -457,9 +457,10 @@
       }
     }
 
-    .checkout-pane-order-summary {
+    .commerce-checkout-sidebar {
       position: sticky;
-      top: 30px;
+      top: 0px;
+      align-self: flex-start;
 
       .order-total-line {
         padding-right: 0;
@@ -469,6 +470,7 @@
         }
       }
     }
+
 
     .fieldset-legend {
       display: block;

--- a/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
+++ b/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
@@ -11,10 +11,10 @@
 #}
 <div class="layout-checkout-form">
   <div class="row">
-    <div class="col-sm-6">
+    <div class="col-sm-6 commerce-checkout-main-content">
       {{ form|without('sidebar', 'actions') }}
     </div>
-    <div class="col-sm-6">
+    <div class="col-sm-6 commerce-checkout-sidebar">
       <h3>{% trans %} Order Summary {% endtrans %}</h3>
       {{ form.sidebar }}
     </div>

--- a/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
+++ b/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
@@ -20,9 +20,6 @@
     </div>
   </div>
   <div class="layout-region-checkout-footer">
-    <div class="btn-back-to-cart-wrapper">
-      <a class="btn-back-to-cart" href="/cart">{{'Zurück zum Warenkorb'|t}}</a>
-    </div>
     {{ form.actions }}
   </div>
 </div>


### PR DESCRIPTION
This PR adds adjusts the checkout form template to allow styling the main content and sidebar column as a whole. It also enables the module's template instead of using the bootstrap barrio's one.

It also styles the commerce promotions button to be a secondary button.