### PR TITLE
DUP-114: remove patch and update commerce_repeat_order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,6 @@
     "drupal/redirect_after_login": "^3.0",
     "drupal/single_datetime": "^2.0",
     "drupal/entity_print": "^2.0",
-    "drupal/commerce_repeat_order": "2.2.0"
-  },
-  "extra": {
-    "patches": {
-      "drupal/commerce_repeat_order": {
-        "[https://dgo.to/3367273]: Drupal 10 compatibility": "https://www.drupal.org/files/issues/2023-09-13/d10_compatibility-3367273-7.patch"
-      }
-    }
+    "drupal/commerce_repeat_order": "^2.4"
   }
 }


### PR DESCRIPTION
This PR removes the patch for D10 compatibility on drupal/commerce_repeat_order as it was fixed and released, and update the module to latest release